### PR TITLE
Update DiffEqGPU.jl example

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,3 +13,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StaticCompiler = "81625895-6c0f-48fc-b932-11a18313743c"
 StaticTools = "86c06d3c-3f03-46de-9781-57580aa96d0a"
 WebAssemblyInterfaces = "74d8c2bb-7b3a-4d47-ac1c-f80c5e9b8189"
+
+
+[compat]
+DiffEqGPU = "2.4"

--- a/index.md
+++ b/index.md
@@ -20,7 +20,6 @@ This is an example app to demonstrate how Julia code for DiffEq-type simulations
 Here is the model with initial conditions that we'll compile. The important part is using [DiffEqGPU](https://github.com/SciML/DiffEqGPU.jl) to set up an integrator. Because it is designed to run on a GPU, it is natural for static compilation. It doesn't allocate or use features from `libjulia`.
 
 ```julia:j1
-# Tested with DiffEqGPU v2.3.1
 using DiffEqGPU, StaticArrays, OrdinaryDiffEq
 
 function lorenz(u, p, t)

--- a/index.md
+++ b/index.md
@@ -20,6 +20,7 @@ This is an example app to demonstrate how Julia code for DiffEq-type simulations
 Here is the model with initial conditions that we'll compile. The important part is using [DiffEqGPU](https://github.com/SciML/DiffEqGPU.jl) to set up an integrator. Because it is designed to run on a GPU, it is natural for static compilation. It doesn't allocate or use features from `libjulia`.
 
 ```julia:j1
+# Tested with DiffEqGPU v2.3.1
 using DiffEqGPU, StaticArrays, OrdinaryDiffEq
 
 function lorenz(u, p, t)
@@ -37,7 +38,7 @@ tspan = (0.0, 20.0)
 p = @SVector [10.0, 28.0, 8 / 3.0]
 prob = ODEProblem{false}(lorenz, u0, tspan, p)
 
-integ = DiffEqGPU.gputsit5_init(GPUTsit5(), lorenz, false, u0, 0.0, 0.005, p, nothing, CallbackSet(nothing), true, false)
+integ = DiffEqGPU.init(GPUTsit5(), prob.f, false, u0, 0.0, 0.005, p, nothing, CallbackSet(nothing), true, false)
 ```
 
 Now, we can define a function to solve this model. We won't use `DiffEqGPU.solve()` because that's too complicated. Instead, we'll use `integ` and manually step through the solution. We'll update solution vectors along the way. 


### PR DESCRIPTION
Some users have followed your tutorial to compile DiffEqGPU solvers with their non-standard hardware. I updated the example with the latest API.